### PR TITLE
feat: add This Week in Rust 642 translation

### DIFF
--- a/posts/this-week-in-rust-642.md
+++ b/posts/this-week-in-rust-642.md
@@ -1,0 +1,508 @@
+---
+pt-BR:
+  title: "This Week in Rust 642"
+  description: "Traducao em portugues da newsletter This Week in Rust 642"
+  body: >-
+    <p>Olá e bem-vindo a mais uma edição da <em>This Week in Rust</em>!
+    <a href="https://www.rust-lang.org/">Rust</a> é uma linguagem de programação que capacita todos a construir software confiável e eficiente.
+    Este é um resumo semanal de seu progresso e comunidade.
+    Quer algo mencionado? Marque-nos em
+    <a href="https://bsky.app/profile/thisweekinrust.bsky.social">@thisweekinrust.bsky.social</a> no Bluesky ou
+    <a href="https://mastodon.social/@thisweekinrust">@ThisWeekinRust</a> no mastodon.social, ou
+    <a href="https://github.com/rust-lang/this-week-in-rust">envie-nos um pull request</a>.
+    Quer se envolver? <a href="https://github.com/rust-lang/rust/blob/main/CONTRIBUTING.md">Adoramos contribuições</a>.</p>
+    <p><em>This Week in Rust</em> é desenvolvida abertamente <a href="https://github.com/rust-lang/this-week-in-rust">no GitHub</a> e os arquivos podem ser visualizados em <a href="https://this-week-in-rust.org/">this-week-in-rust.org</a>.
+    Se você encontrar algum erro na edição desta semana, <a href="https://github.com/rust-lang/this-week-in-rust/pulls">por favor envie um PR</a>.</p>
+    <p>Quer a TWIR na sua caixa de entrada? <a href="https://this-week-in-rust.us11.list-manage.com/subscribe?u=fd84c1c757e02889a9b08d289&id=0ed8b72485">Inscreva-se aqui</a>.</p>
+    <h2 id="updates-from-rust-community"><a class="toclink" href="#updates-from-rust-community">Atualizações da Comunidade Rust</a></h2>
+    <!--
+    
+    Dear community contributors:
+    Please read README.md for guidance on submissions.
+    Each submitted link should be of the form:
+    
+    * [Title of the linked Page](https://example.com/my_article)
+    
+    If you add a link to a non-text content please prefix it with `[video]` or `[audio]`:
+    
+    * [video] [Title of the linked video](https://example.com/my_video_article)
+    * [audio] [Title of the linked audio file](https://example.com/my_podcast)
+    
+    If you don't know which category to use, feel free to submit a PR anyway
+    and just ask the editors to select the category.
+    
+    -->
+    
+    <h3 id="official"><a class="toclink" href="#official">Oficial</a></h3>
+    <ul>
+    <li><a href="https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/">Announcing Rust 1.94.0 | Rust Blog</a></li>
+    </ul>
+    <h3 id="newsletters"><a class="toclink" href="#newsletters">Newsletters</a></h3>
+    <ul>
+    <li><a href="https://weeklyrust.substack.com/p/state-of-rust-survey-findings">🦀 State of Rust Survey Findings</a></li>
+    </ul>
+    <h3 id="projecttooling-updates"><a class="toclink" href="#projecttooling-updates">Atualizações de Projetos/Ferramentas</a></h3>
+    <ul>
+    <li><a href="https://github.com/uutils/coreutils/releases/tag/0.7.0">Release 0.7.0 · uutils/coreutils</a></li>
+    <li><a href="https://github.com/bahdotsh/mdterm/releases/tag/v1.0.0">mdterm v1.0.0 - A terminal-based Markdown browser</a></li>
+    <li><a href="https://dev.to/vloldik/the-anatomy-of-a-500ns-parser-porting-libphonenumber-to-rust-3daa">The Anatomy of a 500ns Parser: Porting libphonenumber to Rust</a></li>
+    <li><a href="https://dev.to/rajmandaliya/building-a-rust-ai-agent-framework-from-scratch-what-i-learned-3o23">mini-agent: A Rust AI Agent Framework</a></li>
+    <li><a href="https://www.sea-ql.org/blog/2026-03-08-sea-clickhouse/">ClickHouse meets SeaORM: Arrow-powered data pipeline</a></li>
+    <li><a href="https://rustaceans.ai/">Rustaceans.AI</a></li>
+    <li><a href="https://www.openanalytics.eu/blog/2026/03/09/leptodon-1.0.0/">Leptodon 1.0.0: UI toolkit for the Leptos WASM framework</a></li>
+    <li><a href="https://d34dl0ck.me/cargo-codesign/index.html">Signing Rust Binaries Shouldn't Require Shell Scripts</a></li>
+    </ul>
+    <h3 id="observationsthoughts"><a class="toclink" href="#observationsthoughts">Observações/Reflexões</a></h3>
+    <ul>
+    <li><a href="https://iev.ee/blog/symbolic-derivatives-and-the-rust-rewrite-of-resharp/">symbolic derivatives and the rust rewrite of RE# | ian erik varatalu</a></li>
+    <li><a href="https://cetra3.github.io/blog/state-of-allocators-2026/">The State of Allocators in 2026</a></li>
+    <li>[series] <a href="https://zaynar.co.uk/posts/f2rust-1/">FORTRAN to Rust: part 1</a></li>
+    <li><a href="https://blog.sebastiansastre.co/posts/cost-of-indirection-in-rust/">The Cost of Indirection in Rust</a></li>
+    <li><a href="https://opeolluwa.github.io/almonds/blog/why-not-js-database">Why SeaORM over JavaScript client database options?</a></li>
+    <li><a href="https://kerkour.com/rust-eating-postgres">Rust is slowly but surely eating PostgreSQL: Deep dive into Neon, ParadeDB, PgDog and more</a></li>
+    <li><a href="https://www.rodriguez.today/articles/emergent-event-driven-workflows">What Happens When You Constrain an Event-Driven System to Three Primitives</a></li>
+    <li><a href="https://bitfieldconsulting.com/posts/rust-dev-tools">My Rust dev setup in 2026</a></li>
+    <li>[audio] <a href="https://netstack.fm/#episode-30">Netstack.FM episode 30 — uReq with Martin Algesten</a></li>
+    <li><a href="https://www.kdab.com/weighing-up-zngur-and-cxx-for-rustc-interop/">Weighing up Zngur and CXX for Rust/C++ Interop</a></li>
+    </ul>
+    <h3 id="rust-walkthroughs"><a class="toclink" href="#rust-walkthroughs">Tutoriais de Rust</a></h3>
+    <ul>
+    <li><a href="https://rustarians.com/polynomials-in-zk-snarks/">ZK snarks for rust developer part 1/8</a></li>
+    <li><a href="https://abhikja.in/blog/2026-03-10-get-in-line-part-2/">Get in Line (Part 2) - Vyukov's Queue and its specializations</a></li>
+    <li><a href="https://contextgeneric.dev/blog/rustlab-2025-coherence/">How to stop fighting with coherence and start writing context-generic trait impls</a></li>
+    <li><a href="https://medium.com/airtable-eng/rewriting-our-database-in-rust-f64e37a482ef">Rewriting Our Database in Rust</a></li>
+    <li><a href="https://signoz.io/blog/opentelemetry-rust/">OpenTelemetry for Rust Developers - The Complete Implementation Guide</a></li>
+    </ul>
+    <h3 id="miscellaneous"><a class="toclink" href="#miscellaneous">Diversos</a></h3>
+    <ul>
+    <li><a href="https://smiling.dev/blog/rust-shined-over-python-for-my-cli-tool/">Rust Shined Over Python for My CLI Tool - Smiling Dev Blog</a></li>
+    <li><a href="https://llogiq.github.io/2026/03/05/auto.html">Write small Rust scripts</a></li>
+    </ul>
+    <h2 id="crate-of-the-week"><a class="toclink" href="#crate-of-the-week">Crate da Semana</a></h2>
+    <p>O crate desta semana é <a href="https://github.com/wikimedia/sentencex">sentencex</a>, uma biblioteca rápida de segmentação de frases.</p>
+    <p>Obrigado a <a href="https://users.rust-lang.org/t/crate-of-the-week/2704/1564">Santhosh Thottingal</a> pela autosugestão!</p>
+    <p><a href="https://users.rust-lang.org/t/crate-of-the-week/2704">Por favor, envie suas sugestões e votos para a próxima semana</a>!</p>
+    <h2 id="calls-for-testing"><a class="toclink" href="#calls-for-testing">Chamadas para Testes</a></h2>
+    <p>Um passo importante para a implementação de RFCs é que as pessoas experimentem a
+    implementação e forneçam feedback, especialmente antes da estabilização.</p>
+    <p>Se você é um implementador de funcionalidades e gostaria que sua RFC aparecesse nesta lista, adicione uma
+    label <code>call-for-testing</code> à sua RFC junto com um comentário fornecendo instruções de teste e/ou
+    orientação sobre qual(is) aspecto(s) da funcionalidade precisa(m) de testes.</p>
+    <p><em>Nenhuma chamada para testes foi emitida esta semana por
+    <a href="https://github.com/rust-lang/rust/issues?q=state%3Aopen%20label%3Acall-for-testing%20state%3Aopen">Rust</a>,
+    <a href="https://github.com/rust-lang/cargo/issues?q=state%3Aopen%20label%3Acall-for-testing%20state%3Aopen">Cargo</a>,
+    <a href="https://github.com/rust-lang/rustup/issues?q=state%3Aopen%20label%3Acall-for-testing%20state%3Aopen">Rustup</a> ou
+    <a href="https://github.com/rust-lang/rfcs/issues?q=label%3Acall-for-testing%20state%3Aopen">Rust language RFCs</a>.</em></p>
+    <p><a href="https://github.com/rust-lang/this-week-in-rust/issues">Avise-nos</a> se você gostaria que sua funcionalidade fosse rastreada como parte desta lista.</p>
+    <h2 id="call-for-participation-projects-and-speakers"><a class="toclink" href="#call-for-participation-projects-and-speakers">Chamada para Participação; projetos e palestrantes</a></h2>
+    <h3 id="cfp-projects"><a class="toclink" href="#cfp-projects">CFP - Projetos</a></h3>
+    <p>Sempre quis contribuir para projetos de código aberto mas não sabia por onde começar?
+    Toda semana destacamos algumas tarefas da comunidade Rust para você escolher e começar!</p>
+    <p>Algumas dessas tarefas também podem ter mentores disponíveis, visite a página da tarefa para mais informações.</p>
+    <!-- CFPs go here, use this format: * [project name - title of issue](URL to issue) -->
+    <ul>
+    <li><a href="https://github.com/ayarotsky/diesel-guard/issues/89">diesel-guard - REFRESH MATERIALIZED VIEW without CONCURRENTLY</a></li>
+    <li><a href="https://github.com/ayarotsky/diesel-guard/issues/88">diesel-guard - ADD CHECK CONSTRAINT without NOT VALID</a></li>
+    <li><a href="https://github.com/ayarotsky/diesel-guard/issues/87">diesel-guard - ADD FOREIGN KEY without NOT VALID</a></li>
+    <li><a href="https://github.com/ayarotsky/diesel-guard/issues/97">diesel-guard - no lock_timeout/statement_timeout before DDL</a></li>
+    </ul>
+    <!-- or if none - *No Calls for participation were submitted this week.* -->
+    
+    <p>Se você é dono de um projeto Rust e está procurando por contribuidores, por favor envie tarefas <a href="https://github.com/rust-lang/this-week-in-rust?tab=readme-ov-file#call-for-participation-guidelines">aqui</a> ou através de um <a href="https://github.com/rust-lang/this-week-in-rust">PR para a TWiR</a> ou entrando em contato no <a href="https://bsky.app/profile/thisweekinrust.bsky.social">Bluesky</a> ou <a href="https://mastodon.social/@thisweekinrust">Mastodon</a>!</p>
+    <h3 id="cfp-events"><a class="toclink" href="#cfp-events">CFP - Eventos</a></h3>
+    <p>Você é um palestrante novo ou experiente procurando um lugar para compartilhar algo legal? Esta seção destaca eventos que estão sendo planejados e estão aceitando submissões para se juntar ao evento como palestrante.</p>
+    <!-- CFPs go here, use this format: * [**event name**](URL to CFP)| Date CFP closes in YYYY-MM-DD | city,state,country | Date of event in YYYY-MM-DD -->
+    <!-- or if none - *No Calls for papers or presentations were submitted this week.* -->
+    
+    <ul>
+    <li><a href="https://hasgeek.com/rustbangalore/cfp-rust-india-conference-2026/"><strong>Rust India Conference 2026</strong></a> | CFP aberto até 2026-03-14 | Bangalore, IN | 2026-04-18</li>
+    <li><a href="https://pretalx.com/oxidize-conference-2026-2025/cfp"><strong>Oxidize Conference</strong></a> | CFP aberto até 2026-03-23 | Berlin, Germany | 2026-09-14 - 2026-09-16</li>
+    <li><a href="https://sessionize.com/eurorust-2026/"><strong>EuroRust</strong></a> | CFP aberto até 2026-04-27 | Barcelona, Spain | 2026-10-14 - 2026-10-17</li>
+    </ul>
+    <p>Se você é um organizador de eventos esperando expandir o alcance do seu evento, por favor envie um link para o site através de um <a href="https://github.com/rust-lang/this-week-in-rust">PR para a TWiR</a> ou entrando em contato no <a href="https://bsky.app/profile/thisweekinrust.bsky.social">Bluesky</a> ou <a href="https://mastodon.social/@thisweekinrust">Mastodon</a>!</p>
+    <h2 id="updates-from-the-rust-project"><a class="toclink" href="#updates-from-the-rust-project">Atualizações do Projeto Rust</a></h2>
+    <p>483 pull requests foram <a href="https://github.com/search?q=is%3Apr+org%3Arust-lang+is%3Amerged+merged%3A2026-03-03..2026-03-10">mesclados na última semana</a></p>
+    <h4 id="compiler"><a class="toclink" href="#compiler">Compilador</a></h4>
+    <ul>
+    <li><a href="https://github.com/rust-lang/rust/pull/153361">enable <code>PassMode::Indirect { on_stack: true, .. }</code> tail call arguments</a></li>
+    </ul>
+    <h4 id="library"><a class="toclink" href="#library">Biblioteca</a></h4>
+    <ul>
+    <li><a href="https://github.com/rust-lang/rust/pull/153399">constify <code>Vec::{into, from}_raw_parts{_in|_alloc}</code></a></li>
+    <li><a href="https://github.com/rust-lang/rust/pull/150447">implement <code>MaybeDangling</code> compiler support</a></li>
+    <li><a href="https://github.com/rust-lang/rust/pull/152911">stabilize <code>control_flow_ok</code></a></li>
+    </ul>
+    <h4 id="cargo"><a class="toclink" href="#cargo">Cargo</a></h4>
+    <ul>
+    <li><a href="https://github.com/rust-lang/cargo/pull/16721"><code>compile</code>: Turn warning summaries into errors also</a></li>
+    <li><a href="https://github.com/rust-lang/cargo/pull/16711"><code>fix</code>: Switch from ad-hoc to structured warnings</a></li>
+    <li><a href="https://github.com/rust-lang/cargo/pull/16714"><code>script</code>: surpress <code>unused_features</code> lint for embedded</a></li>
+    <li><a href="https://github.com/rust-lang/cargo/pull/16698"><code>tests</code>: allow for 'could not' as well as couldn't in test output</a></li>
+    <li><a href="https://github.com/rust-lang/cargo/pull/16688">add missing truncate when writing <code>.crate</code> files</a></li>
+    <li><a href="https://github.com/rust-lang/cargo/pull/16677">ignore implicit std dependencies in <code>unused-crate-dependencies</code> lint</a></li>
+    <li><a href="https://github.com/rust-lang/cargo/pull/16459">let git decide when to run gc</a></li>
+    <li><a href="https://github.com/rust-lang/cargo/pull/16708">split <code>build-dir</code> lock into dedicated lock</a></li>
+    </ul>
+    <h4 id="clippy"><a class="toclink" href="#clippy">Clippy</a></h4>
+    <ul>
+    <li><a href="https://github.com/rust-lang/rust-clippy/pull/16582">add <code>manual_pop_if</code> lint</a></li>
+    <li><a href="https://github.com/rust-lang/rust-clippy/pull/16514"><code>doc_paragraphs_missing_punctuation</code>: Trim picture symbols</a></li>
+    <li><a href="https://github.com/rust-lang/rust-clippy/pull/16666">do not materialize snippets when it is not needed to</a></li>
+    <li><a href="https://github.com/rust-lang/rust-clippy/pull/16685">fix ICE in <code>match_same_arms</code></a></li>
+    <li><a href="https://github.com/rust-lang/rust-clippy/pull/16659">fix ICE in <code>swap_binop()</code></a></li>
+    <li><a href="https://github.com/rust-lang/rust-clippy/pull/16692">fix ICE when using the <code>min_generic_const_args</code> incomplete feature</a></li>
+    <li><a href="https://github.com/rust-lang/rust-clippy/pull/16619">fix <code>infinite_loop</code> wrong suggestion inside conditional branches</a></li>
+    <li><a href="https://github.com/rust-lang/rust-clippy/pull/16648">fix <code>redundant_closure</code> suggests wrongly when local is derefed to callable</a></li>
+    <li><a href="https://github.com/rust-lang/rust-clippy/pull/16559">fix <code>unnecessary_safety_comment</code> false positive on code blocks inside inner docs</a></li>
+    <li><a href="https://github.com/rust-lang/rust-clippy/pull/16697">fix semicolon-inside-block inside <code>try_blocks</code></a></li>
+    <li><a href="https://github.com/rust-lang/rust-clippy/pull/16652">optimize <code>allow_unwrap_types</code> evaluation to eliminate performance regression</a></li>
+    </ul>
+    <h4 id="rust-analyzer"><a class="toclink" href="#rust-analyzer">Rust-Analyzer</a></h4>
+    <ul>
+    <li><a href="https://github.com/rust-lang/rust-analyzer/pull/21788">do not re-query source roots per crate in analysis-stats</a></li>
+    <li><a href="https://github.com/rust-lang/rust-analyzer/pull/21687">offer <code>destructure_struct_binding</code> on self param</a></li>
+    <li><a href="https://github.com/rust-lang/rust-analyzer/pull/21752">when going to def on <code>?</code> on <code>Result</code> that goes through <code>From</code>, go to the <code>From</code> impl</a></li>
+    <li><a href="https://github.com/rust-lang/rust-analyzer/pull/21755">add <code>has_pending</code> methods to <code>Incoming</code>/<code>Outgoing</code>/<code>ReqQueue</code> in <code>lsp_server</code></a></li>
+    <li><a href="https://github.com/rust-lang/rust-analyzer/pull/21705"><code>cfg_select</code> supports non token-tree tokens</a></li>
+    <li><a href="https://github.com/rust-lang/rust-analyzer/pull/21726">align <code>is_rust()</code> with rustc by correcting constructor ABI in next solver</a></li>
+    <li><a href="https://github.com/rust-lang/rust-analyzer/pull/21750">do not use PostAnalysis TypingMode for IDE method resolution</a></li>
+    <li><a href="https://github.com/rust-lang/rust-analyzer/pull/21771">file watcher should watch directories recursively</a></li>
+    <li><a href="https://github.com/rust-lang/rust-analyzer/pull/21728">fix wrong descend range for <code>add_missing_match_arms</code></a></li>
+    <li><a href="https://github.com/rust-lang/rust-analyzer/pull/21671">offer block <code>.let</code> in ref-expr in match arm</a></li>
+    </ul>
+    <h3 id="rust-compiler-performance-triage"><a class="toclink" href="#rust-compiler-performance-triage">Triagem de Performance do Compilador Rust</a></h3>
+    <p>Quase nenhuma regressão esta semana, enquanto houve um punhado de melhorias de desempenho
+    causadas pela refatoração contínua do sistema de consultas do compilador. A maior foi de
+    <a href="https://github.com/rust-lang/rust/pull/153521">#153521</a>.</p>
+    <p>Triagem feita por <strong>@kobzol</strong>.
+    Intervalo de revisão: <a href="https://perf.rust-lang.org/?start=ddd36bd57051f796850345b76c17e9402e28a9e4&end=3945997aabf6165261ef3419534c1ad59d9dc5c6&absolute=false&stat=instructions%3Au">ddd36bd5..3945997a</a></p>
+    <p><strong>Resumo</strong>:</p>
+    <table>
+    <thead>
+    <tr>
+    <th align="center">(instructions:u)</th>
+    <th align="center">média</th>
+    <th align="center">intervalo</th>
+    <th align="center">contagem</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+    <td align="center">Regressões ❌ <br /> (primário)</td>
+    <td align="center">0.4%</td>
+    <td align="center">[0.4%, 0.5%]</td>
+    <td align="center">3</td>
+    </tr>
+    <tr>
+    <td align="center">Regressões ❌ <br /> (secundário)</td>
+    <td align="center">0.6%</td>
+    <td align="center">[0.1%, 1.2%]</td>
+    <td align="center">8</td>
+    </tr>
+    <tr>
+    <td align="center">Melhorias ✅ <br /> (primário)</td>
+    <td align="center">-0.9%</td>
+    <td align="center">[-2.5%, -0.1%]</td>
+    <td align="center">110</td>
+    </tr>
+    <tr>
+    <td align="center">Melhorias ✅ <br /> (secundário)</td>
+    <td align="center">-0.8%</td>
+    <td align="center">[-2.7%, -0.1%]</td>
+    <td align="center">77</td>
+    </tr>
+    <tr>
+    <td align="center">Todos ❌✅ (primário)</td>
+    <td align="center">-0.9%</td>
+    <td align="center">[-2.5%, 0.5%]</td>
+    <td align="center">113</td>
+    </tr>
+    </tbody>
+    </table>
+    <p>0 Regressões, 6 Melhorias, 3 Mistos; 5 deles em rollups
+    31 comparações de artefatos feitas no total</p>
+    <p><a href="https://github.com/rust-lang/rustc-perf/blob/4bb67d679eabb4cf31dd545c89498a861e937d75/triage/2026/2026-03-10.md">Relatório completo aqui</a>.</p>
+    <h3 id="approved-rfcs"><a class="toclink" href="#approved-rfcs"><a href="https://github.com/rust-lang/rfcs/commits/master">RFCs Aprovadas</a></a></h3>
+    <p>Mudanças no Rust seguem o <a href="https://github.com/rust-lang/rfcs#rust-rfcs">processo RFC (request for comments)</a>. Estas
+    são as RFCs que foram aprovadas para implementação esta semana:</p>
+    <ul>
+    <li><em>Nenhuma RFC foi aprovada esta semana.</em></li>
+    </ul>
+    <h3 id="final-comment-period"><a class="toclink" href="#final-comment-period">Período Final de Comentários</a></h3>
+    <p>Toda semana, <a href="https://www.rust-lang.org/team.html">a equipe</a> anuncia o 'período final de comentários' para RFCs e PRs importantes
+    que estão chegando a uma decisão. Expresse suas opiniões agora.</p>
+    <h4 id="tracking-issues-prs"><a class="toclink" href="#tracking-issues-prs">Tracking Issues & PRs</a></h4>
+    <h5 id="rust"><a class="toclink" href="#rust"><a href="https://github.com/rust-lang/rust/issues?q=is%3Aopen%20label%3Afinal-comment-period%20sort%3Aupdated-desc%20state%3Aopen">Rust</a></a></h5>
+    <ul>
+    <li><a href="https://github.com/rust-lang/rust/pull/153041">Remove <code>ATTRIBUTE_ORDER</code></a></li>
+    </ul>
+    <p><em>Nenhum item entrou no Período Final de Comentários esta semana para
+    <a href="https://github.com/rust-lang/rfcs/issues?q=state%3Aopen%20label%3Afinal-comment-period%20state%3Aopen">Rust RFCs</a>,
+    <a href="https://github.com/rust-lang/cargo/issues?q=is%3Aopen%20label%3Afinal-comment-period%20sort%3Aupdated-desc%20state%3Aopen">Cargo</a>,
+    <a href="https://github.com/rust-lang/compiler-team/issues?q=label%3Amajor-change%20label%3Afinal-comment-period%20state%3Aopen">Compiler Team</a> <a href="https://forge.rust-lang.org/compiler/mcp.html">(apenas MCPs)</a>,
+    <a href="https://github.com/rust-lang/lang-team/issues?q=is%3Aopen%20label%3Afinal-comment-period%20sort%3Aupdated-desc%20state%3Aopen">Language Team</a>,
+    <a href="https://github.com/rust-lang/reference/issues?q=is%3Aopen%20label%3Afinal-comment-period%20sort%3Aupdated-desc%20state%3Aopen">Language Reference</a>,
+    <a href="https://github.com/rust-lang/leadership-council/issues?q=state%3Aopen%20label%3Afinal-comment-period%20state%3Aopen">Leadership Council</a> ou
+    <a href="https://github.com/rust-lang/unsafe-code-guidelines/issues?q=is%3Aopen%20label%3Afinal-comment-period%20sort%3Aupdated-desc%20state%3Aopen">Unsafe Code Guidelines</a>.</em></p>
+    <p>Avise-nos se você gostaria que seus PRs, Tracking Issues ou RFCs fossem rastreados como parte desta lista.</p>
+    <h3 id="new-and-updated-rfcs"><a class="toclink" href="#new-and-updated-rfcs"><a href="https://github.com/rust-lang/rfcs/pulls">RFCs Novas e Atualizadas</a></a></h3>
+    <ul>
+    <li><a href="https://github.com/rust-lang/rfcs/pull/3926">RFC: Custom lint profiles</a></li>
+    </ul>
+    <h2 id="upcoming-events"><a class="toclink" href="#upcoming-events">Próximos Eventos</a></h2>
+    <p>Eventos Rust entre 2026-03-11 - 2026-04-08 🦀</p>
+    <h3 id="virtual"><a class="toclink" href="#virtual">Virtual</a></h3>
+    <ul>
+    <li>2026-03-11 | Virtual (Girona, ES) | <a href="https://lu.ma/rust-girona">Rust Girona</a><ul>
+    <li><a href="https://luma.com/cgzfpzcp"><strong>Sessió setmanal de codificació / Weekly coding session</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-12 | Virtual (Berlin, DE) | <a href="https://www.meetup.com/rust-berlin">Rust Berlin</a><ul>
+    <li><a href="https://www.meetup.com/rust-berlin/events/308455924/"><strong>Rust Hack and Learn</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-17 | Virtual (Washington, DC, US) | <a href="https://www.meetup.com/rustdc">Rust DC</a><ul>
+    <li><a href="https://www.meetup.com/rustdc/events/313490537/"><strong>Mid-month Rustful</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-18 | Híbrido (Vancouver, BC, CA) | <a href="https://www.meetup.com/vancouver-rust">Vancouver Rust</a><ul>
+    <li><a href="https://www.meetup.com/vancouver-rust/events/313471716/"><strong>Embedded Rust</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-18 | Virtual (Cardiff, UK) | <a href="https://www.meetup.com/rust-and-c-plus-plus-in-cardiff">Rust and C++ Cardiff</a><ul>
+    <li><a href="https://www.meetup.com/rust-and-c-plus-plus-in-cardiff/events/313621933/"><strong>Hybrid event with Rust Dortmund!</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-18 | Virtual (Girona, ES) | <a href="https://lu.ma/rust-girona">Rust Girona</a><ul>
+    <li><a href="https://luma.com/45qqc2eo"><strong>Sessió setmanal de codificació / Weekly coding session</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-19 | Híbrido (Seattle, WA, US) | <a href="https://www.meetup.com/join-srug">Seattle Rust User Group</a><ul>
+    <li><a href="https://www.meetup.com/seattle-rust-user-group/events/312274882/"><strong>March, 2026 SRUG (Seattle Rust User Group) Meetup</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-20 | Virtual | <a href="https://www.eventbrite.com/o/70306584013">Packt Publishing Limited</a><ul>
+    <li><a href="https://www.eventbrite.com/e/rust-adoption-safety-and-cloud-with-francesco-ciulla-registration-1981847709850"><strong>Rust Adoption, Safety, and Cloud with Francesco Ciulla</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-24 | Virtual (Dallas, TX, US) | <a href="https://www.meetup.com/dallasrust">Dallas Rust User Meetup</a><ul>
+    <li><a href="https://www.meetup.com/dallasrust/events/310254785/"><strong>Fourth Tuesday</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-24 | Virtual (London, UK) | <a href="https://www.meetup.com/women-in-rust">Women in Rust</a><ul>
+    <li><a href="https://www.meetup.com/women-in-rust/events/312799496/"><strong>Lunch & Learn: Crates, Tips & Tricks Lightning Talks - Bring your ideas!</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-25 | Virtual (Girona, ES) | <a href="https://lu.ma/rust-girona">Rust Girona</a><ul>
+    <li><a href="https://luma.com/vq9w8q0w"><strong>Rust Girona Hack & Learn 03 2026</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-26 | Virtual (Berlin, DE) | <a href="https://www.meetup.com/rust-berlin">Rust Berlin</a><ul>
+    <li><a href="https://www.meetup.com/rust-berlin/events/308455925/"><strong>Rust Hack and Learn</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-04-01 | Virtual (Girona, ES) | <a href="https://lu.ma/rust-girona">Rust Girona</a><ul>
+    <li><a href="https://luma.com/me4jwgxu"><strong>Sessió setmanal de codificació / Weekly coding session</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-04-01 | Virtual (Indianapolis, IN, US) | <a href="https://www.meetup.com/indyrs">Indy Rust</a><ul>
+    <li><a href="https://www.meetup.com/indyrs/events/wqzhftyjcgbcb/"><strong>Indy.rs - with Social Distancing</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-04-02 | Virtual (Nürnberg, DE) | <a href="https://www.meetup.com/rust-noris">Rust Nuremberg</a><ul>
+    <li><a href="https://www.meetup.com/rust-noris/events/313345237/"><strong>Rust Nürnberg online</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-04-04 | Virtual (Kampala, UG) | <a href="https://www.eventbrite.com/e/rust-circle-meetup-tickets-628763176587">Rust Circle Meetup</a><ul>
+    <li><a href="https://www.eventbrite.com/e/rust-circle-meetup-tickets-628763176587"><strong>Rust Circle Meetup</strong></a></li>
+    </ul>
+    </li>
+    </ul>
+    <h3 id="asia"><a class="toclink" href="#asia">Ásia</a></h3>
+    <ul>
+    <li>2026-03-22 | Tel Aviv-yafo, IL | <a href="https://www.meetup.com/rust-tlv">Rust 🦀 TLV</a><ul>
+    <li><a href="https://www.meetup.com/rust-tlv/events/312862609/"><strong>In person Rust March 2026 at AWS in Tel Aviv</strong></a></li>
+    </ul>
+    </li>
+    </ul>
+    <h3 id="europe"><a class="toclink" href="#europe">Europa</a></h3>
+    <ul>
+    <li>2026-03-11 | Amsterdam, NL | <a href="https://www.meetup.com/rust-amsterdam-group">Rust Developers Amsterdam Group</a><ul>
+    <li><a href="https://www.meetup.com/rust-amsterdam-group/events/313426708/"><strong>Meetup @ Instruqt</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-11 | Frankfurt, DE | <a href="https://www.meetup.com/rust-rhein-main">Rust Rhein-Main</a><ul>
+    <li><a href="https://www.meetup.com/rust-rhein-main/events/313617138/"><strong>Writing a Python compiler in Rust</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-12 | Bern, CH | <a href="https://www.meetup.com/rust-bern">Rust Bern</a><ul>
+    <li><a href="https://www.meetup.com/rust-bern/events/313443248/"><strong>2026 Rust Talks Bern #1 @bespinian</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-12 | Geneva, CH | <a href="https://www.posttenebraslab.ch/">Post Tenebras Lab</a><ul>
+    <li><a href="https://www.posttenebraslab.ch/wiki/events/monthly_meeting/rust_meetup"><strong>Rust Meetup Geneva</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-18 | Dortmund, DE | <a href="https://www.meetup.com/rust-dortmund">Rust Dortmund</a><ul>
+    <li><a href="https://www.meetup.com/rust-dortmund/events/313338784/"><strong>Rust Dortmund Meetup - Intro to Embedded Rust - March</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-19 - 2026-03-20 | Warsaw, PL | <a href="https://www.rustikon.dev/">Rustikon</a><ul>
+    <li><a href="https://www.rustikon.dev/"><strong>Rustikon Conference</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-23 | Augsburg, DE | <a href="https://rust-augsburg.github.io/meetup">Rust Meetup Augsburg</a><ul>
+    <li><a href="https://rust-augsburg.github.io/meetup/Meetup_18.html"><strong>Rust Meetup #18</strong>: Ludwig Weinzierl - Bevy: Spielentwicklung mit Rust</a></li>
+    </ul>
+    </li>
+    <li>2026-03-24 | Aarhus, DK | <a href="https://www.meetup.com/rust-aarhus">Rust Aarhus</a><ul>
+    <li><a href="https://www.meetup.com/rust-aarhus/events/313284304/"><strong>Hack Night - Advent of Code</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-24 | Manchester, UK | <a href="https://www.meetup.com/rust-manchester">Rust Manchester</a><ul>
+    <li><a href="https://www.meetup.com/rust-manchester/events/313495449/"><strong>Rust Manchester March Code Night</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-24 | Trondheim, NO | <a href="https://www.meetup.com/rust-trondheim">Rust Trondheim</a><ul>
+    <li><a href="https://www.meetup.com/rust-trondheim/events/313537618/"><strong>Rust projects - show and tell in March</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-26 | Paris, FR | <a href="https://www.meetup.com/rust-paris">Rust Paris</a><ul>
+    <li><a href="https://www.meetup.com/rust-paris/events/313646981/"><strong>Rust meetup #84</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-27 | Paris, FR | <a href="https://www.rustinparis.com/">Rust in Paris</a><ul>
+    <li><a href="https://www.rustinparis.com/"><strong>Rust in Paris</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-04-01 | Oxford, UK | <a href="https://www.meetup.com/oxford-rust-meetup-group">Oxford ACCU/Rust Meetup.</a><ul>
+    <li><a href="https://www.meetup.com/oxford-rust-meetup-group/events/312664491/"><strong>Rust/ACCU meetup.</strong></a></li>
+    </ul>
+    </li>
+    </ul>
+    <h3 id="north-america"><a class="toclink" href="#north-america">América do Norte</a></h3>
+    <ul>
+    <li>2026-03-12 | Lehi, UT, US | <a href="https://www.meetup.com/utah-rust">Utah Rust</a><ul>
+    <li><a href="https://www.meetup.com/utah-rust/events/313506767/"><strong>An Interpreter for Computability theory, Written the Hard Way</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-12 | San Diego, CA, US | <a href="https://www.meetup.com/san-diego-rust">San Diego Rust</a><ul>
+    <li><a href="https://www.meetup.com/san-diego-rust/events/313721867/"><strong>San Diego Rust March Meetup - Back in person!</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-14 | Boston, MA, US | <a href="https://www.meetup.com/bostonrust">Boston Rust Meetup</a><ul>
+    <li><a href="https://www.meetup.com/bostonrust/events/313208587/"><strong>North End Rust Lunch, Mar 14</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-17 | San Francisco, CA, US | <a href="https://www.meetup.com/san-francisco-rust-study-group">San Francisco Rust Study Group</a><ul>
+    <li><a href="https://www.meetup.com/san-francisco-rust-study-group/events/313404095/"><strong>Rust Hacking in Person</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-18 | Híbrido (Vancouver, BC, CA) | <a href="https://www.meetup.com/vancouver-rust">Vancouver Rust</a><ul>
+    <li><a href="https://www.meetup.com/vancouver-rust/events/313471716/"><strong>Embedded Rust</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-19 | Híbrido (Seattle, WA, US) | <a href="https://www.meetup.com/join-srug">Seattle Rust User Group</a><ul>
+    <li><a href="https://www.meetup.com/seattle-rust-user-group/events/312274882/"><strong>March, 2026 SRUG (Seattle Rust User Group) Meetup</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-19 | Mountain View, CA, US | <a href="https://www.meetup.com/hackerdojo/events/">Hacker Dojo</a><ul>
+    <li><a href="https://www.meetup.com/hackerdojo/events/313569258/"><strong>RUST MEETUP at HACKER DOJO</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-19 | Nashville, TN, US | <a href="https://www.meetup.com/music-city-rust-developers">Music City Rust Developers</a><ul>
+    <li><a href="https://www.meetup.com/music-city-rust-developers/events/313576317/"><strong>Applied Rust - Building Rust Applictions</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-19 | New York, NY, US | <a href="https://www.meetup.com/rust-nyc">Rust NYC</a><ul>
+    <li><a href="https://www.meetup.com/rust-nyc/events/313639707/"><strong>Rust NYC: Social Interoperability - Rust, C++ and The Greater Good</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-21 | Boston, MA, US | <a href="https://www.meetup.com/bostonrust">Boston Rust Meetup</a><ul>
+    <li><a href="https://www.meetup.com/bostonrust/events/313208597/"><strong>Porter Square Rust Lunch, Mar 21</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-25 | Austin, TX, US | <a href="https://www.meetup.com/rust-atx">Rust ATX</a><ul>
+    <li><a href="https://www.meetup.com/rust-atx/events/313653030/"><strong>Rust Lunch - Fareground</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-25 | New York, NY, US | <a href="https://www.meetup.com/rust-nyc">Rust NYC</a><ul>
+    <li><a href="https://www.meetup.com/rust-nyc/events/313713085/"><strong>Rust NYC's Digital Asset Adoption Special</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-26 | Atlanta, GA, US | <a href="https://www.meetup.com/rust-atl">Rust Atlanta</a><ul>
+    <li><a href="https://www.meetup.com/rust-atl/events/311228658/"><strong>Rust-Atl</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-04-02 | Saint Louis, MO, US | <a href="https://www.meetup.com/stl-rust">STL Rust</a><ul>
+    <li><a href="https://www.meetup.com/stl-rust/events/313482094/"><strong>SIUE Cruft Crawler with LLM</strong></a></li>
+    </ul>
+    </li>
+    </ul>
+    <h3 id="oceania"><a class="toclink" href="#oceania">Oceania</a></h3>
+    <ul>
+    <li>2026-03-12 | Brisbane City, AU | <a href="https://www.meetup.com/rust-brisbane">Rust Brisbane</a><ul>
+    <li><a href="https://www.meetup.com/rust-brisbane/events/313596218/"><strong>Rust Brisbane Mar 2026</strong></a></li>
+    </ul>
+    </li>
+    <li>2026-03-26 | Melbourne, AU | <a href="https://www.meetup.com/rust-melbourne">Rust Melbourne</a><ul>
+    <li><a href="https://www.meetup.com/rust-melbourne/events/313471749/"><strong>TBD March Meetup</strong></a></li>
+    </ul>
+    </li>
+    </ul>
+    <h3 id="south-america"><a class="toclink" href="#south-america">América do Sul</a></h3>
+    <ul>
+    <li>2026-03-21 | São Paulo, BR | <a href="https://www.meetup.com/rust-sao-paulo-meetup">Rust São Paulo Meetup</a><ul>
+    <li><a href="https://www.meetup.com/rust-sao-paulo-meetup/events/313446400/"><strong>Encontro do Rust-SP (migrado pro Lumma)</strong></a></li>
+    </ul>
+    </li>
+    </ul>
+    <p>Se você está organizando um evento Rust, por favor adicione-o ao <a href="https://www.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc%40group.calendar.google.com">calendário</a> para que
+    seja mencionado aqui. Por favor, lembre-se de adicionar um link para o evento também.
+    Envie um email para a <a href="mailto:community-team@rust-lang.org">Equipe da Comunidade Rust</a> para obter acesso.</p>
+    <h2 id="jobs"><a class="toclink" href="#jobs">Vagas</a></h2>
+    <p>Por favor, veja a última <a href="https://www.reddit.com/r/rust/comments/1rmra27/official_rrust_whos_hiring_thread_for_jobseekers/">thread Who's Hiring no r/rust</a></p>
+    <h1 id="quote-of-the-week"><a class="toclink" href="#quote-of-the-week">Citação da Semana</a></h1>
+    <blockquote>
+    <p>Feliz dia do "Clippy, você é muito útil" para aqueles que celebram!</p>
+    </blockquote>
+    <p>– <a href="https://functional.cafe/@manpacket/116178060408287449">Manpacket no functional.cafe</a></p>
+    <p>Apesar de uma falta lamentável de sugestões, llogiq está extremamente satisfeito com sua escolha.</p>
+    <p><a href="https://users.rust-lang.org/t/twir-quote-of-the-week/328">Por favor, envie citações e vote para a próxima semana!</a></p>
+    <p>This Week in Rust é editada por:</p>
+    <ul>
+    <li><a href="https://github.com/nellshamrell">nellshamrell</a></li>
+    <li><a href="https://github.com/llogiq">llogiq</a></li>
+    <li><a href="https://github.com/ericseppanen">ericseppanen</a></li>
+    <li><a href="https://github.com/extrawurst">extrawurst</a></li>
+    <li><a href="https://github.com/U007D">U007D</a></li>
+    <li><a href="https://github.com/mariannegoldin">mariannegoldin</a></li>
+    <li><a href="https://github.com/bdillo">bdillo</a></li>
+    <li><a href="https://github.com/opeolluwa">opeolluwa</a></li>
+    <li><a href="https://github.com/bnchi">bnchi</a></li>
+    <li><a href="https://github.com/KannanPalani57">KannanPalani57</a></li>
+    <li><a href="https://github.com/tzilist">tzilist</a></li>
+    </ul>
+    <p><em>A hospedagem da lista de e-mail é patrocinada pela <a href="https://foundation.rust-lang.org/">The Rust Foundation</a></em></p>
+    <p><small><a href="https://www.reddit.com/r/rust/comments/1rre8o9/this_week_in_rust_642/">Discuta no r/rust</a></small></p>
+    
+    ---
+    
+    *Artigo original: [https://this-week-in-rust.org/blog/2026/03/11/this-week-in-rust-642/](https://this-week-in-rust.org/blog/2026/03/11/this-week-in-rust-642/)*
+    
+    *Traduzido automaticamente por IA. Para sugestoes de melhorias, abra uma issue no repositorio.*
+  date: 2026-03-11 01:00:00
+  image: /images/ESSA-SEMANA-COM-RUST-FINAL.png
+  main-class: rust
+  color: "#CE422B"
+  tags:
+    - rust
+    - newsletter
+    - this-week-in-rust
+    - traducao
+en:
+  title: "This Week in Rust 642"
+  description: "Original newsletter link"
+  body: >-
+    *Original post: [https://this-week-in-rust.org/blog/2026/03/11/this-week-in-rust-642/](https://this-week-in-rust.org/blog/2026/03/11/this-week-in-rust-642/)*
+---


### PR DESCRIPTION
## New translation: This Week in Rust

This PR adds the Brazilian Portuguese translation for **This Week in Rust 642**.

### Checklist
- [x] Content translated automatically
- [ ] Manual review pending
- [ ] Links verified
- [ ] Markdown formatting verified

### File
- \

---
*This PR was created automatically by the twir bash CLI.*